### PR TITLE
Fix extra row width and input zoom on iOS

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     .card{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:16px}
     .span-7{grid-column:span 7} .span-5{grid-column:span 5} .span-12{grid-column:span 12}
     label{display:block;font-size:.9rem;color:var(--muted);margin-bottom:6px}
-    input,select,button{width:100%;padding:12px;border-radius:10px;border:1px solid var(--border);background:#0b1220;color:#e5e7eb;outline:none; -webkit-appearance:none}
+    input,select,button{width:100%;padding:12px;border-radius:10px;border:1px solid var(--border);background:#0b1220;color:#e5e7eb;outline:none; -webkit-appearance:none;font-size:16px}
     input[type="date"]{padding:10px}
     input[type="number"]::-webkit-outer-spin-button,
     input[type="number"]::-webkit-inner-spin-button{-webkit-appearance:none;margin:0}
@@ -42,8 +42,8 @@
     .hr{height:1px;background:var(--border);margin:10px 0}
     .help{font-size:.85rem;color:var(--muted)}
     .tag{display:inline-block;background:#0b1220;border:1px solid var(--border);border-radius:8px;padding:4px 8px;margin-right:6px}
-    .mini-table{overflow:auto;border:1px solid var(--border);border-radius:10px; -webkit-overflow-scrolling: touch}
-    .mini-table table{table-layout:fixed; width:640px; min-width:640px}
+    .mini-table{overflow:auto;border:1px solid var(--border);border-radius:10px; -webkit-overflow-scrolling: touch; width:100%}
+    .mini-table table{table-layout:fixed; width:100%; min-width:640px}
     .mini-table th:nth-child(1), .mini-table td:nth-child(1){width:40px;text-align:center}
     .mini-table th:nth-child(2), .mini-table td:nth-child(2){width:140px;text-align:center}
     .mini-table th:nth-child(3), .mini-table td:nth-child(3){width:160px}


### PR DESCRIPTION
## Summary
- Prevent extra contribution rows from expanding layout width
- Set inputs to 16px font-size to avoid iOS auto-zoom

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdee2177b883319cec445cf38ce7d7